### PR TITLE
Added compatibility for WT32-ETH01 - ESP32 Board with Ethernet Socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Adds NTP capabilities to the ESPHome platform.
 
 ** Fixed duplicate sources in "NTP Server info"
+** Fixed Ethernet/Wifi compatibility
 
 ## Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Adds NTP capabilities to the ESPHome platform.
 
 ** Fixed duplicate sources in "NTP Server info"
+
 ** Fixed Ethernet/Wifi compatibility
 
 ## Basic Usage

--- a/components/ntp_server/ntp_server.cpp
+++ b/components/ntp_server/ntp_server.cpp
@@ -113,7 +113,7 @@ void processNTP() {
     #ifdef USE_WIFI
     IPAddress myIP = wifi::global_wifi_component->get_ip_addresses()[0];
     #else
-    IPAddress myIP = ethernet::global_ethernet_component->get_ip_addresses()[0];
+    IPAddress myIP = ethernet::global_eth_component->get_ip_addresses()[0];
     #endif
     packetBuffer[12] = myIP[0];
     packetBuffer[13] = myIP[1];

--- a/components/ntp_server/ntp_server.cpp
+++ b/components/ntp_server/ntp_server.cpp
@@ -1,5 +1,10 @@
 #include "esphome.h"
+#ifdef USE_WIFI
 #include "esphome/components/wifi/wifi_component.h"
+#else 
+#include "esphome/components/ethernet/ethernet_component.h"
+#endif
+
 #include <WiFiUdp.h>
 
 WiFiUDP Udp;

--- a/components/ntp_server/ntp_server.cpp
+++ b/components/ntp_server/ntp_server.cpp
@@ -110,7 +110,11 @@ void processNTP() {
     tempval = timestamp;
 
     // Set refid to IP address if not locked
+    #ifdef USE_WIFI
     IPAddress myIP = wifi::global_wifi_component->get_ip_addresses()[0];
+    #else
+    IPAddress myIP = ethernet::global_ethernet_component->get_ip_addresses()[0];
+    #endif
     packetBuffer[12] = myIP[0];
     packetBuffer[13] = myIP[1];
     packetBuffer[14] = myIP[2];


### PR DESCRIPTION
WT32-ETH01 has an Ethernet port already added to it. If you use the ntp_server component in ethernet mode you get into trouble since the Wifi Libraries are not available.